### PR TITLE
Fix the GitHub pagination

### DIFF
--- a/service_github.go
+++ b/service_github.go
@@ -56,9 +56,9 @@ func (s *githubService) refresh() {
 		page = resp.NextPage
 	}
 
+	s.has2fa = make([]string, 0)
 	page = 1
 	for page != 0 {
-		s.has2fa = make([]string, 0)
 		usersWith2fa, resp, err := s.client.Organizations.ListMembers(s.org, &github.ListMembersOptions{
 			Filter:      "all",
 			ListOptions: github.ListOptions{Page: page},


### PR DESCRIPTION
With this line in the loop (as it was previously), we would only get the
last page full of data.
